### PR TITLE
Add realtime socket server and gameplay APIs

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,6 +19,7 @@
         "nodemailer": "^6.9.16",
         "react": "19.1.0",
         "react-dom": "19.1.0",
+        "socket.io": "^4.8.1",
         "tailwind-merge": "^2.5.2",
         "tailwindcss-animate": "^1.0.7"
       },
@@ -1608,6 +1609,12 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@socket.io/component-emitter": {
+      "version": "3.1.2",
+      "resolved": "https://registry.npmjs.org/@socket.io/component-emitter/-/component-emitter-3.1.2.tgz",
+      "integrity": "sha512-9BCxFwvbGg/RsZK9tjXd8s4UcwR0MWeFQ1XEKIQVVvAGJyINdrqKMcTRyLoK8Rse1GjzLV9cwjWV1olXRWEXVA==",
+      "license": "MIT"
+    },
     "node_modules/@standard-schema/spec": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/@standard-schema/spec/-/spec-1.0.0.tgz",
@@ -1635,6 +1642,15 @@
         "tslib": "^2.4.0"
       }
     },
+    "node_modules/@types/cors": {
+      "version": "2.8.19",
+      "resolved": "https://registry.npmjs.org/@types/cors/-/cors-2.8.19.tgz",
+      "integrity": "sha512-mFNylyeyqN93lfe/9CSxOGREz8cpzAhH+E93xJ4xWQf62V8sQ/24reV2nyzUWM6H6Xji+GGHpkbLe7pVoUEskg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.8.tgz",
@@ -1660,7 +1676,6 @@
       "version": "20.19.17",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-20.19.17.tgz",
       "integrity": "sha512-gfehUI8N1z92kygssiuWvLiwcbOB3IRktR6hTDgJlXMYh5OvkPSRmgfoBUmfZt+vhwJtX7v1Yw4KvvAf7c5QKQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~6.21.0"
@@ -2243,6 +2258,19 @@
         "win32"
       ]
     },
+    "node_modules/accepts": {
+      "version": "1.3.8",
+      "resolved": "https://registry.npmjs.org/accepts/-/accepts-1.3.8.tgz",
+      "integrity": "sha512-PYAthTa2m2VKxuvSD3DPC/Gy+U+sOA1LAuT8mkmRuvw+NACSaeXEQ+NHcVF7rONl6qcaxV3Uuemwawk+7+SJLw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-types": "~2.1.34",
+        "negotiator": "0.6.3"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2608,6 +2636,15 @@
       "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.2.tgz",
       "integrity": "sha512-3oSeUO0TMV67hN1AmbXsK4yaqU7tjiHlbxRDZOpH0KW9+CeX4bRAaX0Anxt0tx2MrpRpWwQaPwIlISEJhYU5Pw==",
       "license": "MIT"
+    },
+    "node_modules/base64id": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/base64id/-/base64id-2.0.0.tgz",
+      "integrity": "sha512-lGe34o6EHj9y3Kts9R4ZYs/Gr+6N7MCaMlIFA3F1R2O5/m7K06AxfSeO5530PEERE6/WyEg3lsuyw4GHlPZHog==",
+      "license": "MIT",
+      "engines": {
+        "node": "^4.5.0 || >= 5.9"
+      }
     },
     "node_modules/baseline-browser-mapping": {
       "version": "2.8.6",
@@ -2996,6 +3033,28 @@
         "node": "^14.18.0 || >=16.10.0"
       }
     },
+    "node_modules/cookie": {
+      "version": "0.7.2",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
+      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/cors": {
+      "version": "2.8.5",
+      "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.5.tgz",
+      "integrity": "sha512-KIHbLJqu73RGr/hnbrO9uBeixNGuvSQjul/jdFvS/KFSIH1hWVd1ng7zOHx+YrEfInLG7q4n6GHQ9cDtxv/P6g==",
+      "license": "MIT",
+      "dependencies": {
+        "object-assign": "^4",
+        "vary": "^1"
+      },
+      "engines": {
+        "node": ">= 0.10"
+      }
+    },
     "node_modules/cross-spawn": {
       "version": "7.0.6",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
@@ -3276,6 +3335,52 @@
       "license": "MIT",
       "engines": {
         "node": ">=14"
+      }
+    },
+    "node_modules/engine.io": {
+      "version": "6.6.4",
+      "resolved": "https://registry.npmjs.org/engine.io/-/engine.io-6.6.4.tgz",
+      "integrity": "sha512-ZCkIjSYNDyGn0R6ewHDtXgns/Zre/NT6Agvq1/WobF7JXgFff4SeDroKiCO3fNJreU9YG429Sc81o4w5ok/W5g==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/cors": "^2.8.12",
+        "@types/node": ">=10.0.0",
+        "accepts": "~1.3.4",
+        "base64id": "2.0.0",
+        "cookie": "~0.7.2",
+        "cors": "~2.8.5",
+        "debug": "~4.3.1",
+        "engine.io-parser": "~5.2.1",
+        "ws": "~8.17.1"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/engine.io-parser": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/engine.io-parser/-/engine.io-parser-5.2.3.tgz",
+      "integrity": "sha512-HqD3yTBfnBxIrbnM1DoD6Pcq8NECnh8d4As1Qgh0z5Gg3jRRIqijury0CL3ghu/edArpUYiYqQiDUQBIs4np3Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/engine.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
       }
     },
     "node_modules/es-abstract": {
@@ -5300,6 +5405,27 @@
         "node": ">=8.6"
       }
     },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
     "node_modules/minimatch": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.2.tgz",
@@ -5336,7 +5462,6 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/mz": {
@@ -5390,6 +5515,15 @@
       "integrity": "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/negotiator": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/negotiator/-/negotiator-0.6.3.tgz",
+      "integrity": "sha512-+EUsqGPLsM+j/zdChZjsnX51g4XrHFOIXwfnCVPGlQk/k5giakcKsuxCObBRu6DSm9opw/O6slWbJdghQM4bBg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
     },
     "node_modules/next": {
       "version": "15.5.3",
@@ -6663,6 +6797,98 @@
         "url": "https://github.com/sponsors/isaacs"
       }
     },
+    "node_modules/socket.io": {
+      "version": "4.8.1",
+      "resolved": "https://registry.npmjs.org/socket.io/-/socket.io-4.8.1.tgz",
+      "integrity": "sha512-oZ7iUCxph8WYRHHcjBEc9unw3adt5CmSNlppj/5Q4k2RIrhl8Z5yY2Xr4j9zj0+wzVZ0bxmYoGSzKJnRl6A4yg==",
+      "license": "MIT",
+      "dependencies": {
+        "accepts": "~1.3.4",
+        "base64id": "~2.0.0",
+        "cors": "~2.8.5",
+        "debug": "~4.3.2",
+        "engine.io": "~6.6.0",
+        "socket.io-adapter": "~2.5.2",
+        "socket.io-parser": "~4.2.4"
+      },
+      "engines": {
+        "node": ">=10.2.0"
+      }
+    },
+    "node_modules/socket.io-adapter": {
+      "version": "2.5.5",
+      "resolved": "https://registry.npmjs.org/socket.io-adapter/-/socket.io-adapter-2.5.5.tgz",
+      "integrity": "sha512-eLDQas5dzPgOWCk9GuuJC2lBqItuhKI4uxGgo9aIV7MYbk2h9Q6uULEh8WBzThoI7l+qU9Ast9fVUmkqPP9wYg==",
+      "license": "MIT",
+      "dependencies": {
+        "debug": "~4.3.4",
+        "ws": "~8.17.1"
+      }
+    },
+    "node_modules/socket.io-adapter/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io-parser": {
+      "version": "4.2.4",
+      "resolved": "https://registry.npmjs.org/socket.io-parser/-/socket.io-parser-4.2.4.tgz",
+      "integrity": "sha512-/GbIKmo8ioc+NIWIhwdecY0ge+qVBSMdgxGygevmdHj24bsfgtCmcUUcQ5ZzcylGFHsN3k4HB4Cgkl96KVnuew==",
+      "license": "MIT",
+      "dependencies": {
+        "@socket.io/component-emitter": "~3.1.0",
+        "debug": "~4.3.1"
+      },
+      "engines": {
+        "node": ">=10.0.0"
+      }
+    },
+    "node_modules/socket.io-parser/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/socket.io/node_modules/debug": {
+      "version": "4.3.7",
+      "resolved": "https://registry.npmjs.org/debug/-/debug-4.3.7.tgz",
+      "integrity": "sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "ms": "^2.1.3"
+      },
+      "engines": {
+        "node": ">=6.0"
+      },
+      "peerDependenciesMeta": {
+        "supports-color": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -7341,7 +7567,6 @@
       "version": "6.21.0",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-6.21.0.tgz",
       "integrity": "sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==",
-      "dev": true,
       "license": "MIT"
     },
     "node_modules/unrs-resolver": {
@@ -7425,6 +7650,15 @@
       "resolved": "https://registry.npmjs.org/util-deprecate/-/util-deprecate-1.0.2.tgz",
       "integrity": "sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==",
       "license": "MIT"
+    },
+    "node_modules/vary": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/vary/-/vary-1.1.2.tgz",
+      "integrity": "sha512-BNGbWLfd0eUPabhkXUVm0j8uuvREyTh5ovRa/dyow/BqAbZJyC+5fU+IzQOzmAKzYqYRAISoRhdQr3eIZ/PXqg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/which": {
       "version": "2.0.2",
@@ -7626,6 +7860,27 @@
       },
       "funding": {
         "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/ws": {
+      "version": "8.17.1",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.17.1.tgz",
+      "integrity": "sha512-6XQFvXTkbfUOZOKKILFG1PDK2NDQs4azKQl26T0YS5CxqWLgXajbPZ+h4gZekJyRqFU8pvnbAbbs/3TgRPy+GQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
       }
     },
     "node_modules/yaml": {

--- a/package.json
+++ b/package.json
@@ -16,17 +16,18 @@
     "db:seed": "prisma db seed"
   },
   "dependencies": {
-    "@radix-ui/react-slot": "^1.1.1",
     "@auth/prisma-adapter": "^2.7.3",
     "@prisma/client": "^6.3.1",
+    "@radix-ui/react-slot": "^1.1.1",
     "class-variance-authority": "^0.7.0",
     "clsx": "^2.1.1",
     "lucide-react": "^0.474.0",
+    "next": "15.5.3",
     "next-auth": "^5.0.0-beta.25",
     "nodemailer": "^6.9.16",
-    "next": "15.5.3",
     "react": "19.1.0",
     "react-dom": "19.1.0",
+    "socket.io": "^4.8.1",
     "tailwind-merge": "^2.5.2",
     "tailwindcss-animate": "^1.0.7"
   },

--- a/src/app/api/ai/continue/route.ts
+++ b/src/app/api/ai/continue/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from "next/server";
+
+import { rhymeHeuristic, sanitize } from "@/lib/text";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { previousLine } = body ?? {};
+
+    const sanitized = typeof previousLine === "string" ? sanitize(previousLine) : "";
+    const suggestion = sanitized
+      ? `${sanitized.split(" ").slice(-1)[0] ?? ""} delight ignites the night`
+      : "Words await your spark tonight.";
+
+    const rhyme = sanitized ? rhymeHeuristic(sanitized, suggestion) : { score: 0, fragment: null };
+
+    return NextResponse.json({ suggestion, rhyme });
+  } catch (error) {
+    console.error("AI continue mock failed", error);
+    return NextResponse.json({ error: "Unable to generate suggestion." }, { status: 500 });
+  }
+}

--- a/src/app/api/ai/judge/route.ts
+++ b/src/app/api/ai/judge/route.ts
@@ -1,0 +1,26 @@
+import { NextResponse } from "next/server";
+
+import { wordCount } from "@/lib/text";
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { prompt, submission } = body ?? {};
+
+    if (typeof submission !== "string") {
+      return NextResponse.json({ error: "A submission is required." }, { status: 400 });
+    }
+
+    const words = wordCount(submission);
+    const accepted = words % 2 === 0;
+    const verdict = accepted ? "approve" : "revise";
+    const reasoning = accepted
+      ? "Submission length looks balanced and rhythmic."
+      : "Try adjusting the length for a more balanced cadence.";
+
+    return NextResponse.json({ verdict, reasoning, prompt, metrics: { words } });
+  } catch (error) {
+    console.error("AI judge mock failed", error);
+    return NextResponse.json({ error: "Unable to evaluate submission." }, { status: 500 });
+  }
+}

--- a/src/app/api/rooms/[id]/join/route.ts
+++ b/src/app/api/rooms/[id]/join/route.ts
@@ -1,0 +1,49 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { emitToRoom } from "@/lib/realtime/server";
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const body = await request.json();
+    const { userId, role } = body ?? {};
+
+    if (!userId || typeof userId !== "string") {
+      return NextResponse.json({ error: "A userId is required to join a room." }, { status: 400 });
+    }
+
+    const membership = await prisma.membership.upsert({
+      where: {
+        userId_roomId: {
+          userId,
+          roomId: params.id,
+        },
+      },
+      update: {
+        role: role ?? undefined,
+      },
+      create: {
+        userId,
+        roomId: params.id,
+        role: role ?? undefined,
+      },
+    });
+
+    const participantCount = await prisma.membership.count({ where: { roomId: params.id } });
+
+    emitToRoom(params.id, "room:joined", {
+      roomId: params.id,
+      participants: participantCount,
+      userId,
+    });
+
+    return NextResponse.json({ membership });
+  } catch (error) {
+    console.error(`Failed to join room ${params.id}`, error);
+    return NextResponse.json({ error: "Unable to join room." }, { status: 500 });
+  }
+}

--- a/src/app/api/rooms/[id]/recap/route.ts
+++ b/src/app/api/rooms/[id]/recap/route.ts
@@ -1,0 +1,30 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  try {
+    const summaries = await prisma.summary.findMany({
+      where: { roomId: params.id },
+      orderBy: { createdAt: "desc" },
+      include: {
+        turn: {
+          select: {
+            id: true,
+            round: true,
+            prompt: true,
+          },
+        },
+      },
+    });
+
+    return NextResponse.json({ summaries });
+  } catch (error) {
+    console.error(`Failed to fetch recap for room ${params.id}`, error);
+    return NextResponse.json({ error: "Unable to fetch recap." }, { status: 500 });
+  }
+}

--- a/src/app/api/rooms/[id]/route.ts
+++ b/src/app/api/rooms/[id]/route.ts
@@ -1,0 +1,47 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function GET(_request: Request, { params }: RouteParams) {
+  try {
+    const room = await prisma.room.findUnique({
+      where: { id: params.id },
+      include: {
+        memberships: {
+          include: {
+            user: {
+              select: {
+                id: true,
+                name: true,
+                image: true,
+              },
+            },
+          },
+        },
+        turns: {
+          orderBy: { round: "asc" },
+          include: {
+            votes: true,
+            summary: true,
+          },
+        },
+        summaries: {
+          orderBy: { createdAt: "desc" },
+        },
+      },
+    });
+
+    if (!room) {
+      return NextResponse.json({ error: "Room not found." }, { status: 404 });
+    }
+
+    return NextResponse.json({ room });
+  } catch (error) {
+    console.error(`Failed to load room ${params.id}`, error);
+    return NextResponse.json({ error: "Unable to load room." }, { status: 500 });
+  }
+}

--- a/src/app/api/rooms/[id]/start/route.ts
+++ b/src/app/api/rooms/[id]/start/route.ts
@@ -1,0 +1,40 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { emitToRoom, startRoomTimer } from "@/lib/realtime/server";
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const body = await request.json();
+    const { hostId, duration } = body ?? {};
+
+    const room = await prisma.room.update({
+      where: { id: params.id },
+      data: {
+        status: "ACTIVE",
+        hostId: hostId ?? undefined,
+      },
+    });
+
+    const payload = {
+      roomId: params.id,
+      startedAt: new Date().toISOString(),
+      hostId: room.hostId,
+    };
+
+    emitToRoom(params.id, "room:started", payload);
+
+    if (typeof duration === "number" && duration >= 0) {
+      startRoomTimer(params.id, duration);
+    }
+
+    return NextResponse.json({ room, event: payload });
+  } catch (error) {
+    console.error(`Failed to start room ${params.id}`, error);
+    return NextResponse.json({ error: "Unable to start room." }, { status: 500 });
+  }
+}

--- a/src/app/api/rooms/[id]/turn/route.ts
+++ b/src/app/api/rooms/[id]/turn/route.ts
@@ -1,0 +1,113 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { emitToRoom } from "@/lib/realtime/server";
+import { DEFAULT_TURN_VALIDATION, validateTurn } from "@/lib/turn-validation";
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const body = await request.json();
+    const { action, round, prompt, content, authorId, turnId, validationOptions } = body ?? {};
+
+    if (!action || !["propose", "validate", "publish"].includes(action)) {
+      return NextResponse.json({ error: "A valid action is required." }, { status: 400 });
+    }
+
+    if (typeof round !== "number" || round < 0) {
+      return NextResponse.json({ error: "Round must be a positive number." }, { status: 400 });
+    }
+
+    if (action === "propose" && (!prompt || typeof prompt !== "string")) {
+      return NextResponse.json({ error: "A prompt is required." }, { status: 400 });
+    }
+
+    if ((action === "validate" || action === "publish") && typeof turnId !== "string") {
+      return NextResponse.json(
+        { error: "An existing turnId is required for this action." },
+        { status: 400 },
+      );
+    }
+
+    const validation = validateTurn(content ?? "", {
+      ...DEFAULT_TURN_VALIDATION,
+      ...validationOptions,
+    });
+
+    if (!validation.isValid) {
+      return NextResponse.json({ error: "Turn failed validation.", validation }, { status: 422 });
+    }
+
+    if (action === "propose") {
+      const turn = await prisma.turn.create({
+        data: {
+          roomId: params.id,
+          round,
+          prompt,
+          content: validation.sanitized,
+          authorId: authorId ?? null,
+        },
+      });
+
+      emitToRoom(params.id, "turn:proposed", {
+        roomId: params.id,
+        turnId: turn.id,
+        round: turn.round,
+        prompt: turn.prompt,
+        content: turn.content ?? "",
+        authorId: turn.authorId,
+      });
+
+      return NextResponse.json({ turn, validation });
+    }
+
+    if (action === "validate") {
+      const turn = await prisma.turn.update({
+        where: { id: turnId },
+        data: {
+          content: validation.sanitized,
+          authorId: authorId ?? undefined,
+        },
+      });
+
+      emitToRoom(params.id, "turn:validated", {
+        roomId: params.id,
+        turnId: turn.id,
+        round: turn.round,
+        prompt: turn.prompt,
+        content: turn.content ?? "",
+        authorId: turn.authorId,
+      });
+
+      return NextResponse.json({ turn, validation });
+    }
+
+    const turn = await prisma.turn.update({
+      where: { id: turnId },
+      data: {
+        content: validation.sanitized || undefined,
+        endedAt: new Date(),
+      },
+    });
+
+    const publishedAt = new Date().toISOString();
+
+    emitToRoom(params.id, "turn:published", {
+      roomId: params.id,
+      turnId: turn.id,
+      round: turn.round,
+      prompt: turn.prompt,
+      content: turn.content ?? "",
+      authorId: turn.authorId,
+      publishedAt,
+    });
+
+    return NextResponse.json({ turn, validation });
+  } catch (error) {
+    console.error(`Failed to process turn for room ${params.id}`, error);
+    return NextResponse.json({ error: "Unable to process turn." }, { status: 500 });
+  }
+}

--- a/src/app/api/rooms/[id]/vote/route.ts
+++ b/src/app/api/rooms/[id]/vote/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+import { emitToRoom } from "@/lib/realtime/server";
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const body = await request.json();
+    const { turnId, voterId, value } = body ?? {};
+
+    if (!turnId || typeof turnId !== "string") {
+      return NextResponse.json({ error: "A turnId is required." }, { status: 400 });
+    }
+
+    if (!voterId || typeof voterId !== "string") {
+      return NextResponse.json({ error: "A voterId is required." }, { status: 400 });
+    }
+
+    if (typeof value !== "number" || !Number.isFinite(value)) {
+      return NextResponse.json({ error: "A numeric vote value is required." }, { status: 400 });
+    }
+
+    const vote = await prisma.vote.upsert({
+      where: {
+        turnId_voterId: {
+          turnId,
+          voterId,
+        },
+      },
+      update: { value },
+      create: {
+        turnId,
+        voterId,
+        value,
+      },
+    });
+
+    emitToRoom(params.id, "turn:voted", {
+      roomId: params.id,
+      turnId,
+      voterId,
+      value,
+    });
+
+    return NextResponse.json({ vote });
+  } catch (error) {
+    console.error(`Failed to register vote for room ${params.id}`, error);
+    return NextResponse.json({ error: "Unable to register vote." }, { status: 500 });
+  }
+}

--- a/src/app/api/rooms/route.ts
+++ b/src/app/api/rooms/route.ts
@@ -1,0 +1,54 @@
+import { NextResponse } from "next/server";
+
+import { prisma } from "@/lib/prisma";
+
+const ROOM_CODE_ALPHABET = "ABCDEFGHJKLMNPQRSTUVWXYZ23456789";
+
+function generateRoomCode(length = 6): string {
+  let code = "";
+  for (let i = 0; i < length; i += 1) {
+    const index = Math.floor(Math.random() * ROOM_CODE_ALPHABET.length);
+    code += ROOM_CODE_ALPHABET[index];
+  }
+  return code;
+}
+
+async function createRoomCode(): Promise<string> {
+  // Ensure the room code is unique by retrying until one is available.
+  for (let attempts = 0; attempts < 10; attempts += 1) {
+    const candidate = generateRoomCode();
+    const existing = await prisma.room.findFirst({ where: { code: candidate } });
+    if (!existing) {
+      return candidate;
+    }
+  }
+
+  throw new Error("Failed to generate a unique room code");
+}
+
+export async function POST(request: Request) {
+  try {
+    const body = await request.json();
+    const { title, description, hostId } = body ?? {};
+
+    if (!title || typeof title !== "string") {
+      return NextResponse.json({ error: "A room title is required." }, { status: 400 });
+    }
+
+    const code = await createRoomCode();
+
+    const room = await prisma.room.create({
+      data: {
+        title,
+        description: description ?? null,
+        hostId: hostId ?? null,
+        code,
+      },
+    });
+
+    return NextResponse.json({ room }, { status: 201 });
+  } catch (error) {
+    console.error("Failed to create room", error);
+    return NextResponse.json({ error: "Unable to create room." }, { status: 500 });
+  }
+}

--- a/src/lib/realtime/server.ts
+++ b/src/lib/realtime/server.ts
@@ -1,0 +1,293 @@
+import type { Server as HTTPServer } from "http";
+import { Server, type Namespace, type Socket } from "socket.io";
+
+export interface ServerToClientEvents {
+  "room:joined": (payload: RoomParticipantPayload) => void;
+  "room:started": (payload: RoomStartedPayload) => void;
+  "turn:proposed": (payload: TurnEventPayload) => void;
+  "turn:validated": (payload: TurnEventPayload) => void;
+  "turn:published": (payload: TurnPublishedPayload) => void;
+  "turn:voted": (payload: TurnVotedPayload) => void;
+  "timer:tick": (payload: TimerTickPayload) => void;
+}
+
+export interface ClientToServerEvents {
+  "room:start": (payload: RoomStartedPayload) => void;
+  "turn:propose": (payload: TurnEventPayload) => void;
+  "turn:validate": (payload: TurnEventPayload) => void;
+  "turn:publish": (payload: TurnPublishedPayload) => void;
+  "turn:vote": (payload: TurnVotedPayload) => void;
+  "timer:start": (payload: TimerControlPayload) => void;
+  "timer:stop": () => void;
+}
+
+export interface InterServerEvents {
+  ping: () => void;
+}
+
+export interface SocketData {
+  userId?: string;
+  displayName?: string;
+}
+
+export interface RoomParticipantPayload {
+  roomId: string;
+  participants: number;
+  userId?: string;
+  displayName?: string;
+}
+
+export interface RoomStartedPayload {
+  roomId: string;
+  startedAt: string;
+  hostId?: string | null;
+}
+
+export interface TurnEventPayload {
+  roomId: string;
+  turnId: string;
+  round: number;
+  prompt: string;
+  content: string;
+  authorId?: string | null;
+}
+
+export interface TurnPublishedPayload extends TurnEventPayload {
+  publishedAt: string;
+}
+
+export interface TurnVotedPayload {
+  roomId: string;
+  turnId: string;
+  voterId: string;
+  value: number;
+}
+
+export interface TimerControlPayload {
+  roomId: string;
+  duration: number;
+}
+
+export interface TimerTickPayload {
+  roomId: string;
+  duration: number;
+  remaining: number;
+  isComplete: boolean;
+}
+
+type RoomTimerState = {
+  interval?: NodeJS.Timeout;
+  remaining: number;
+  duration: number;
+};
+
+let io: Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData> | null =
+  null;
+const timers = new Map<string, RoomTimerState>();
+
+function buildNamespaceName(roomId: string): string {
+  return `/rooms/${roomId}`;
+}
+
+function getTimerState(roomId: string): RoomTimerState {
+  const existing = timers.get(roomId);
+  if (existing) {
+    return existing;
+  }
+
+  const state: RoomTimerState = {
+    remaining: 0,
+    duration: 0,
+  };
+
+  timers.set(roomId, state);
+  return state;
+}
+
+function clearRoomTimer(
+  namespace: Namespace<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>,
+  roomId: string,
+): void {
+  const state = timers.get(roomId);
+  if (!state?.interval) {
+    return;
+  }
+
+  clearInterval(state.interval);
+  state.interval = undefined;
+}
+
+function startTimer(
+  namespace: Namespace<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>,
+  roomId: string,
+  duration: number,
+): void {
+  const state = getTimerState(roomId);
+  clearRoomTimer(namespace, roomId);
+
+  state.duration = duration;
+  state.remaining = duration;
+
+  namespace.emit("timer:tick", {
+    roomId,
+    duration,
+    remaining: state.remaining,
+    isComplete: duration === 0,
+  });
+
+  if (duration === 0) {
+    return;
+  }
+
+  state.interval = setInterval(() => {
+    state.remaining -= 1;
+
+    if (state.remaining <= 0) {
+      namespace.emit("timer:tick", {
+        roomId,
+        duration: state.duration,
+        remaining: 0,
+        isComplete: true,
+      });
+      clearRoomTimer(namespace, roomId);
+      return;
+    }
+
+    namespace.emit("timer:tick", {
+      roomId,
+      duration: state.duration,
+      remaining: state.remaining,
+      isComplete: false,
+    });
+  }, 1000);
+}
+
+function onConnection(
+  socket: Socket<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>,
+): void {
+  const namespace = socket.nsp as Namespace<
+    ClientToServerEvents,
+    ServerToClientEvents,
+    InterServerEvents,
+    SocketData
+  >;
+  const roomId = namespace.name.split("/").pop() ?? "";
+
+  const participantPayload: RoomParticipantPayload = {
+    roomId,
+    participants: namespace.sockets.size,
+    userId: socket.data.userId,
+    displayName: socket.data.displayName,
+  };
+
+  namespace.emit("room:joined", participantPayload);
+
+  socket.on("room:start", (payload) => {
+    namespace.emit("room:started", payload);
+  });
+
+  socket.on("turn:propose", (payload) => {
+    namespace.emit("turn:proposed", payload);
+  });
+
+  socket.on("turn:validate", (payload) => {
+    namespace.emit("turn:validated", payload);
+  });
+
+  socket.on("turn:publish", (payload) => {
+    namespace.emit("turn:published", payload);
+  });
+
+  socket.on("turn:vote", (payload) => {
+    namespace.emit("turn:voted", payload);
+  });
+
+  socket.on("timer:start", ({ duration }) => {
+    startTimer(namespace, roomId, duration);
+  });
+
+  socket.on("timer:stop", () => {
+    clearRoomTimer(namespace, roomId);
+  });
+
+  socket.on("disconnect", () => {
+    const updatedPayload: RoomParticipantPayload = {
+      roomId,
+      participants: namespace.sockets.size,
+      userId: socket.data.userId,
+      displayName: socket.data.displayName,
+    };
+    namespace.emit("room:joined", updatedPayload);
+
+    if (namespace.sockets.size === 0) {
+      clearRoomTimer(namespace, roomId);
+      timers.delete(roomId);
+    }
+  });
+}
+
+export function initializeRealtimeServer(
+  httpServer: HTTPServer,
+): Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData> {
+  if (io) {
+    return io;
+  }
+
+  io = new Server<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>(
+    httpServer,
+    {
+      path: "/api/socket.io",
+      cors: { origin: "*" },
+    },
+  );
+
+  io.of(/^\/rooms\/.+$/).on("connection", (socket) => {
+    onConnection(
+      socket as Socket<ClientToServerEvents, ServerToClientEvents, InterServerEvents, SocketData>,
+    );
+  });
+
+  return io;
+}
+
+export function getRealtimeServer(): Server<
+  ClientToServerEvents,
+  ServerToClientEvents,
+  InterServerEvents,
+  SocketData
+> | null {
+  return io;
+}
+
+export function emitToRoom<T extends keyof ServerToClientEvents>(
+  roomId: string,
+  event: T,
+  payload: Parameters<ServerToClientEvents[T]>[0],
+): boolean {
+  if (!io) {
+    return false;
+  }
+
+  io.of(buildNamespaceName(roomId)).emit(event, payload);
+  return true;
+}
+
+export function startRoomTimer(roomId: string, duration: number): boolean {
+  if (!io) {
+    return false;
+  }
+
+  const namespace = io.of(buildNamespaceName(roomId));
+  startTimer(namespace, roomId, duration);
+  return true;
+}
+
+export function stopRoomTimer(roomId: string): boolean {
+  if (!io) {
+    return false;
+  }
+
+  const namespace = io.of(buildNamespaceName(roomId));
+  clearRoomTimer(namespace, roomId);
+  return true;
+}

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -1,0 +1,88 @@
+export interface RhymeDetails {
+  /**
+   * Score between 0 and 1 describing how strongly two strings appear to rhyme.
+   */
+  score: number;
+  /**
+   * The fragment from the candidate string that matched the reference.
+   */
+  fragment: string | null;
+}
+
+const CONTROL_CHARS = /[\u0000-\u001F\u007F]/g;
+const MULTIPLE_SPACES = /\s+/g;
+const RHYME_WORD_REGEX = /[a-zA-Z']+/g;
+
+/**
+ * Normalizes arbitrary user input so it can be shared safely between the client and server.
+ */
+export function sanitize(input: string): string {
+  return input.normalize("NFKC").replace(CONTROL_CHARS, " ").replace(MULTIPLE_SPACES, " ").trim();
+}
+
+/**
+ * Counts the number of words in a given string.
+ */
+export function wordCount(input: string): number {
+  const normalized = sanitize(input);
+  if (!normalized) {
+    return 0;
+  }
+
+  return normalized.split(" ").length;
+}
+
+function extractLastWord(input: string): string | null {
+  const matches = input.toLowerCase().match(RHYME_WORD_REGEX);
+  if (!matches || matches.length === 0) {
+    return null;
+  }
+
+  return matches[matches.length - 1];
+}
+
+function extractRhymeFragment(word: string): string {
+  const vowels = /[aeiouy]/;
+  for (let i = word.length - 1; i >= 0; i -= 1) {
+    if (vowels.test(word[i])) {
+      return word.slice(i);
+    }
+  }
+
+  return word.slice(-2);
+}
+
+/**
+ * Provides a lightweight rhyming heuristic for two strings. The score ranges from 0 to 1,
+ * where higher numbers indicate a stronger rhyme.
+ */
+export function rhymeHeuristic(reference: string, candidate: string): RhymeDetails {
+  const referenceWord = extractLastWord(sanitize(reference));
+  const candidateWord = extractLastWord(sanitize(candidate));
+
+  if (!referenceWord || !candidateWord) {
+    return { score: 0, fragment: null };
+  }
+
+  const referenceFragment = extractRhymeFragment(referenceWord);
+  const candidateFragment = extractRhymeFragment(candidateWord);
+
+  let overlap = 0;
+  const maxLength = Math.max(referenceFragment.length, candidateFragment.length);
+
+  for (let i = 0; i < Math.min(referenceFragment.length, candidateFragment.length); i += 1) {
+    if (
+      referenceFragment[referenceFragment.length - 1 - i] ===
+      candidateFragment[candidateFragment.length - 1 - i]
+    ) {
+      overlap += 1;
+    } else {
+      break;
+    }
+  }
+
+  return {
+    score: maxLength === 0 ? 0 : overlap / maxLength,
+    fragment: overlap === 0 ? null : candidateFragment.slice(candidateFragment.length - overlap),
+  };
+}

--- a/src/lib/turn-validation.ts
+++ b/src/lib/turn-validation.ts
@@ -1,0 +1,100 @@
+import { rhymeHeuristic, type RhymeDetails, sanitize, wordCount } from "@/lib/text";
+
+export interface TurnValidationOptions {
+  maxWords: number;
+  maxSentences: number;
+  forbiddenWords?: string[];
+  requireRhymeWith?: string | null;
+  rhymeThreshold?: number;
+}
+
+export interface TurnValidationResult {
+  isValid: boolean;
+  sanitized: string;
+  wordTotal: number;
+  sentenceTotal: number;
+  rhyme?: RhymeDetails;
+  errors: string[];
+}
+
+export const DEFAULT_TURN_VALIDATION: TurnValidationOptions = {
+  maxWords: 120,
+  maxSentences: 8,
+  forbiddenWords: [],
+  requireRhymeWith: null,
+  rhymeThreshold: 0.4,
+};
+
+function countSentences(input: string): number {
+  if (!input) {
+    return 0;
+  }
+
+  return input
+    .split(/[.!?]+/)
+    .map((segment) => segment.trim())
+    .filter(Boolean).length;
+}
+
+function containsForbiddenWord(input: string, forbidden: string[]): string | null {
+  if (!input || forbidden.length === 0) {
+    return null;
+  }
+
+  const tokens = input.toLowerCase().split(" ");
+  const blacklist = new Set(forbidden.map((word) => word.toLowerCase()));
+
+  for (const token of tokens) {
+    if (blacklist.has(token)) {
+      return token;
+    }
+  }
+
+  return null;
+}
+
+export function validateTurn(
+  content: string,
+  options: TurnValidationOptions = DEFAULT_TURN_VALIDATION,
+): TurnValidationResult {
+  const merged: TurnValidationOptions = {
+    ...DEFAULT_TURN_VALIDATION,
+    ...options,
+    forbiddenWords: options.forbiddenWords ?? DEFAULT_TURN_VALIDATION.forbiddenWords,
+  };
+
+  const sanitized = sanitize(content);
+  const words = wordCount(sanitized);
+  const sentences = countSentences(sanitized);
+  const errors: string[] = [];
+
+  if (words > merged.maxWords) {
+    errors.push(`Turn exceeds the maximum of ${merged.maxWords} words.`);
+  }
+
+  if (sentences > merged.maxSentences) {
+    errors.push(`Turn exceeds the maximum of ${merged.maxSentences} sentences.`);
+  }
+
+  const forbidden = containsForbiddenWord(sanitized.toLowerCase(), merged.forbiddenWords ?? []);
+  if (forbidden) {
+    errors.push(`Turn contains a forbidden word: ${forbidden}.`);
+  }
+
+  let rhyme: RhymeDetails | undefined;
+  if (merged.requireRhymeWith) {
+    rhyme = rhymeHeuristic(merged.requireRhymeWith, sanitized);
+    if (rhyme.score < (merged.rhymeThreshold ?? DEFAULT_TURN_VALIDATION.rhymeThreshold!)) {
+      errors.push("Turn does not appear to rhyme with the previous line.");
+    }
+  }
+
+  return {
+    isValid: errors.length === 0,
+    sanitized,
+    wordTotal: words,
+    sentenceTotal: sentences,
+    rhyme,
+    errors,
+  };
+}


### PR DESCRIPTION
## Summary
- add a Socket.IO realtime gateway that orchestrates room namespaces, event relays, and timer ticks for gameplay
- provide REST handlers for creating rooms, joining, starting, managing turns, voting, and fetching recaps along with mock AI judge/continue endpoints
- share sanitizing, word counting, rhyme scoring, and turn validation helpers between client and server layers

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68cfa2fcd7808333822914d297c8678b