### PR TITLE
fix: mark toast hook as client component

### DIFF
--- a/src/components/ui/use-toast.tsx
+++ b/src/components/ui/use-toast.tsx
@@ -1,3 +1,5 @@
+'use client';
+
 import * as React from "react";
 
 import {


### PR DESCRIPTION
## Summary
- mark the toast hook and toaster component file as a client component so React hooks can be used in Next.js

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68e26ed7452883338b2b10474fdc5ad0