### PR TITLE
Fix Summary-Turn relation by adding unique constraint

### DIFF
--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -147,7 +147,7 @@ model Vote {
 model Summary {
   id        String   @id @default(cuid())
   roomId    String
-  turnId    String?
+  turnId    String?  @unique
   content   String
   createdAt DateTime @default(now())
   room      Room     @relation(fields: [roomId], references: [id], onDelete: Cascade)


### PR DESCRIPTION
## Summary
- ensure the Summary.turnId field is unique to satisfy Prisma's one-to-one relation requirements

## Testing
- docker compose exec app npx prisma migrate dev *(fails: docker not available in environment)*

------
https://chatgpt.com/codex/tasks/task_e_68e271e66a348333b027687a91654d53