### PR TITLE
Fix bcryptjs resolution in Next config

### DIFF
--- a/next.config.ts
+++ b/next.config.ts
@@ -1,7 +1,9 @@
 import type { NextConfig } from "next";
 
 const nextConfig: NextConfig = {
-  /* config options here */
+  experimental: {
+    serverComponentsExternalPackages: ["bcryptjs"],
+  },
 };
 
 export default nextConfig;


### PR DESCRIPTION
## Summary
- allow Next.js to treat bcryptjs as an external server component dependency to resolve module import errors

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3cc2237348333aa0355294135bc89