### PR TITLE
Ensure bcryptjs is installed during Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 
 FROM base AS deps
 COPY package.json package-lock.json ./
-RUN npm ci
+RUN npm ci && npm install bcryptjs@^3.0.2 --no-save
 
 FROM deps AS dev
 ENV NODE_ENV=development


### PR DESCRIPTION
## Summary
- update the dependency installation step so the Docker build explicitly installs bcryptjs

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3d0d2a2f08333940f1b70f08cfd04