### PR TITLE
Add migration to add password hash column

### DIFF
--- a/prisma/migrations/0002_add_password_hash/migration.sql
+++ b/prisma/migrations/0002_add_password_hash/migration.sql
@@ -1,0 +1,2 @@
+-- Add passwordHash column to User
+ALTER TABLE "User" ADD COLUMN "passwordHash" TEXT;


### PR DESCRIPTION
## Summary
- add migration to include the missing `passwordHash` column on the `User` table so credential checks succeed

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3d660ccbc83339574502ec1d89551