### PR TITLE
Ensure sessions persist and expose a registered users list

### DIFF
--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -50,7 +50,7 @@ export default async function RootLayout({
           geistMono.variable,
         )}
       >
-        <AppProviders>
+        <AppProviders session={session}>
           <div className="mx-auto flex min-h-screen w-full max-w-6xl flex-col px-4 pb-10">
             <header className="sticky top-0 z-30 -mx-4 mb-6 border-b bg-background/80 backdrop-blur">
               <div className="mx-auto flex w-full max-w-6xl items-center justify-between px-4 py-4">
@@ -81,6 +81,9 @@ export default async function RootLayout({
                 </nav>
                 <div className="flex items-center gap-2">
                   <ThemeToggle />
+                  <Button asChild size="sm" variant="outline">
+                    <Link href="/users">Users</Link>
+                  </Button>
                   {session?.user ? (
                     <>
                       <Button asChild size="sm" className="hidden sm:inline-flex">

--- a/src/app/users/page.tsx
+++ b/src/app/users/page.tsx
@@ -1,0 +1,88 @@
+import { Metadata } from "next";
+
+import { Badge } from "@/components/ui/badge";
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { prisma } from "@/lib/prisma";
+
+export const metadata: Metadata = {
+  title: "Users",
+  description: "Browse the roster of LingvoJam players and see when they joined the platform.",
+};
+
+export const revalidate = 0;
+
+function formatDate(date: Date) {
+  return new Intl.DateTimeFormat("en-US", {
+    dateStyle: "medium",
+    timeStyle: "short",
+  }).format(date);
+}
+
+export default async function UsersPage() {
+  const users = await prisma.user.findMany({
+    select: {
+      id: true,
+      name: true,
+      email: true,
+      role: true,
+      createdAt: true,
+      updatedAt: true,
+    },
+    orderBy: { createdAt: "desc" },
+  });
+
+  if (users.length === 0) {
+    return (
+      <Card className="mx-auto max-w-2xl">
+        <CardHeader>
+          <CardTitle className="text-2xl">Users</CardTitle>
+          <CardDescription>
+            We&apos;ll display new storytellers here as soon as someone signs up.
+          </CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <div className="space-y-6">
+      <header className="space-y-2">
+        <h1 className="text-3xl font-semibold tracking-tight">Users</h1>
+        <p className="text-sm text-muted-foreground">
+          Registered LingvoJam accounts along with their roles and join dates.
+        </p>
+      </header>
+      <div className="grid gap-4">
+        {users.map((user) => (
+          <Card key={user.id}>
+            <CardHeader className="flex flex-col gap-2 sm:flex-row sm:items-center sm:justify-between">
+              <div>
+                <CardTitle className="text-xl">
+                  {user.name?.trim() || user.email || "Unnamed player"}
+                </CardTitle>
+                <CardDescription>{user.email ?? "No email on record"}</CardDescription>
+              </div>
+              <Badge variant="secondary" className="w-fit uppercase tracking-wide">
+                {user.role.toLowerCase()}
+              </Badge>
+            </CardHeader>
+            <CardContent className="grid gap-2 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">User ID</span>
+                <span className="font-mono text-xs sm:text-sm">{user.id}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Joined</span>
+                <span>{formatDate(user.createdAt)}</span>
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-muted-foreground">Last updated</span>
+                <span>{formatDate(user.updatedAt)}</span>
+              </div>
+            </CardContent>
+          </Card>
+        ))}
+      </div>
+    </div>
+  );
+}

--- a/src/components/providers/app-providers.tsx
+++ b/src/components/providers/app-providers.tsx
@@ -2,17 +2,19 @@
 
 import { SessionProvider } from "next-auth/react";
 import * as React from "react";
+import type { Session } from "next-auth";
 
 import { ThemeProvider } from "@/components/theme-provider";
 import { Toaster } from "@/components/ui/use-toast";
 
 type AppProvidersProps = {
   children: React.ReactNode;
+  session: Session | null;
 };
 
-export function AppProviders({ children }: AppProvidersProps) {
+export function AppProviders({ children, session }: AppProvidersProps) {
   return (
-    <SessionProvider>
+    <SessionProvider session={session}>
       <ThemeProvider>
         {children}
         <Toaster />

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -18,5 +18,6 @@ declare module "next-auth" {
 declare module "next-auth/jwt" {
   interface JWT {
     role?: UserRole;
+    userId?: string;
   }
 }


### PR DESCRIPTION
## Summary
- switch NextAuth to JWT-based sessions and persist user metadata inside the JWT callbacks
- hydrate the SessionProvider with the server session and surface a Users button in the global header
- add a Users page that lists registered accounts with their roles and timestamps

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3d7be3acc83339891344577fe05ec