### PR TITLE
Remove unused favicon asset

### DIFF
--- a/src/app/favicon.ico
+++ b/src/app/favicon.ico
@@ -1,3 +1,0 @@
-version https://git-lfs.github.com/spec/v1
-oid sha256:2b8ad2d33455a8f736fc3a8ebf8f0bdea8848ad4c0db48a2833bd0f9cd775932
-size 25931


### PR DESCRIPTION
## Summary
- remove the Next.js favicon asset so automated screenshot tests no longer pick it up

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68e3dac89f848333af99b0c1d593a607