### PR TITLE
Implement dynamic rooms UI and backend integration

### DIFF
--- a/prisma/migrations/0003_room_configuration/migration.sql
+++ b/prisma/migrations/0003_room_configuration/migration.sql
@@ -1,0 +1,7 @@
+-- Add room configuration fields
+ALTER TABLE "Room"
+  ADD COLUMN "prompts" TEXT[] DEFAULT ARRAY[]::TEXT[] NOT NULL,
+  ADD COLUMN "maxWords" INTEGER DEFAULT 40 NOT NULL,
+  ADD COLUMN "maxSentences" INTEGER DEFAULT 2 NOT NULL,
+  ADD COLUMN "forbiddenWords" TEXT[] DEFAULT ARRAY[]::TEXT[] NOT NULL,
+  ADD COLUMN "rhymeTarget" TEXT;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -88,6 +88,11 @@ model Room {
   description String?
   status      RoomStatus    @default(LOBBY)
   hostId      String?
+  prompts        String[]   @default([])
+  maxWords       Int        @default(40)
+  maxSentences   Int        @default(2)
+  forbiddenWords String[]   @default([])
+  rhymeTarget    String?
   createdAt   DateTime      @default(now())
   updatedAt   DateTime      @updatedAt
   host        User?         @relation("HostedRooms", fields: [hostId], references: [id], onDelete: SetNull)

--- a/prisma/seed.ts
+++ b/prisma/seed.ts
@@ -58,6 +58,15 @@ async function main() {
       code: "DEMO123",
       description: "A seeded session showcasing LingvoJam's core data model.",
       status: RoomStatus.ACTIVE,
+      prompts: [
+        "Kick off the story with a mysterious word.",
+        "Shift perspective to another character.",
+        "Close the scene with a question that lingers.",
+      ],
+      maxWords: 40,
+      maxSentences: 2,
+      forbiddenWords: ["boring", "skip"],
+      rhymeTarget: "golden",
       host: { connect: { id: host.id } },
       memberships: {
         create: [

--- a/src/app/api/rooms/[id]/recap/route.ts
+++ b/src/app/api/rooms/[id]/recap/route.ts
@@ -1,14 +1,15 @@
 import { NextRequest } from "next/server";
 import { chromium } from "playwright-core";
 
-import { buildRoomRecap, roomRuleLabel } from "@/lib/rooms";
+import { roomRuleLabel } from "@/lib/rooms";
+import { buildRoomRecap } from "@/lib/server/rooms";
 
 interface RouteParams {
   params: { id: string };
 }
 
-function buildTextRecap(id: string) {
-  const recap = buildRoomRecap(id);
+async function buildTextRecap(id: string) {
+  const recap = await buildRoomRecap(id);
   if (!recap) {
     return null;
   }
@@ -35,8 +36,8 @@ function buildTextRecap(id: string) {
   return lines.join("\n");
 }
 
-function buildHtmlRecap(id: string) {
-  const recap = buildRoomRecap(id);
+async function buildHtmlRecap(id: string) {
+  const recap = await buildRoomRecap(id);
   if (!recap) {
     return null;
   }
@@ -79,7 +80,7 @@ function buildHtmlRecap(id: string) {
 
 export async function GET(request: NextRequest, { params }: RouteParams) {
   const format = request.nextUrl.searchParams.get("format") ?? "pdf";
-  const textRecap = buildTextRecap(params.id);
+  const textRecap = await buildTextRecap(params.id);
 
   if (!textRecap) {
     return new Response("Room not found", { status: 404 });
@@ -93,7 +94,7 @@ export async function GET(request: NextRequest, { params }: RouteParams) {
     });
   }
 
-  const html = buildHtmlRecap(params.id);
+  const html = await buildHtmlRecap(params.id);
   if (!html) {
     return new Response("Room not found", { status: 404 });
   }

--- a/src/app/api/rooms/[id]/turns/[turnId]/vote/route.ts
+++ b/src/app/api/rooms/[id]/turns/[turnId]/vote/route.ts
@@ -1,0 +1,77 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { toRoomTurn } from "@/lib/server/rooms";
+
+interface RouteParams {
+  params: { id: string; turnId: string };
+}
+
+export async function PATCH(request: Request, { params }: RouteParams) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Not authenticated." }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { value } = body ?? {};
+
+    if (![-1, 0, 1].includes(Number(value))) {
+      return NextResponse.json({ error: "Vote value must be -1, 0, or 1." }, { status: 400 });
+    }
+
+    const membership = await prisma.membership.findFirst({
+      where: { roomId: params.id, userId: session.user.id },
+    });
+
+    if (!membership) {
+      return NextResponse.json({ error: "Join the room before voting." }, { status: 403 });
+    }
+
+    const turn = await prisma.turn.findFirst({
+      where: { id: params.turnId, roomId: params.id },
+      select: { id: true },
+    });
+
+    if (!turn) {
+      return NextResponse.json({ error: "Turn not found." }, { status: 404 });
+    }
+
+    if (Number(value) === 0) {
+      await prisma.vote.deleteMany({
+        where: { turnId: params.turnId, voterId: session.user.id },
+      });
+    } else {
+      await prisma.vote.upsert({
+        where: {
+          turnId_voterId: {
+            turnId: params.turnId,
+            voterId: session.user.id,
+          },
+        },
+        update: { value: Number(value) },
+        create: {
+          turnId: params.turnId,
+          voterId: session.user.id,
+          value: Number(value),
+        },
+      });
+    }
+
+    const updated = await prisma.turn.findUnique({
+      where: { id: params.turnId },
+      include: { votes: true },
+    });
+
+    if (!updated) {
+      return NextResponse.json({ error: "Turn not found after voting." }, { status: 404 });
+    }
+
+    return NextResponse.json({ turn: toRoomTurn(updated) }, { status: 200 });
+  } catch (error) {
+    console.error(`Failed to record vote for turn ${params.turnId}`, error);
+    return NextResponse.json({ error: "Unable to record vote." }, { status: 500 });
+  }
+}

--- a/src/app/api/rooms/[id]/turns/route.ts
+++ b/src/app/api/rooms/[id]/turns/route.ts
@@ -1,0 +1,66 @@
+import { NextResponse } from "next/server";
+
+import { auth } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { toRoomTurn } from "@/lib/server/rooms";
+
+interface RouteParams {
+  params: { id: string };
+}
+
+export async function POST(request: Request, { params }: RouteParams) {
+  try {
+    const session = await auth();
+    if (!session?.user?.id) {
+      return NextResponse.json({ error: "Not authenticated." }, { status: 401 });
+    }
+
+    const body = await request.json();
+    const { content, prompt } = body ?? {};
+
+    if (!content || typeof content !== "string") {
+      return NextResponse.json({ error: "Turn content is required." }, { status: 400 });
+    }
+
+    const room = await prisma.room.findUnique({
+      where: { id: params.id },
+      include: { memberships: { select: { userId: true } } },
+    });
+
+    if (!room) {
+      return NextResponse.json({ error: "Room not found." }, { status: 404 });
+    }
+
+    const isMember = room.memberships.some((membership) => membership.userId === session.user.id);
+    if (!isMember) {
+      return NextResponse.json(
+        { error: "Join the room before submitting turns." },
+        { status: 403 },
+      );
+    }
+
+    const latestTurn = await prisma.turn.findFirst({
+      where: { roomId: params.id },
+      orderBy: { round: "desc" },
+      select: { round: true },
+    });
+    const nextRound = (latestTurn?.round ?? 0) + 1;
+
+    const created = await prisma.turn.create({
+      data: {
+        roomId: params.id,
+        authorId: session.user.id,
+        round: nextRound,
+        prompt: typeof prompt === "string" ? prompt : "",
+        content,
+        endedAt: new Date(),
+      },
+      include: { votes: true },
+    });
+
+    return NextResponse.json({ turn: toRoomTurn(created) }, { status: 201 });
+  } catch (error) {
+    console.error(`Failed to create turn for room ${params.id}`, error);
+    return NextResponse.json({ error: "Unable to submit turn." }, { status: 500 });
+  }
+}

--- a/src/app/highlights/page.tsx
+++ b/src/app/highlights/page.tsx
@@ -2,15 +2,15 @@ import { Metadata } from "next";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { listHighlights, getRoomSnapshot } from "@/lib/rooms";
+import { listHighlights } from "@/lib/server/rooms";
 
 export const metadata: Metadata = {
   title: "Highlights",
   description: "Top turns and memorable prompts from across the LingvoJam community.",
 };
 
-export default function HighlightsPage() {
-  const highlights = listHighlights();
+export default async function HighlightsPage() {
+  const highlights = await listHighlights();
 
   return (
     <div className="space-y-8">
@@ -21,30 +21,22 @@ export default function HighlightsPage() {
         </p>
       </header>
       <div className="grid gap-6 sm:grid-cols-2">
-        {highlights.map((highlight) => {
-          const room = getRoomSnapshot(highlight.roomId);
-          return (
-            <Card key={highlight.id} className="h-full">
-              <CardHeader>
-                <CardTitle className="flex items-center justify-between text-lg">
-                  {highlight.title}
-                  {room && <Badge variant="outline">{room.code}</Badge>}
-                </CardTitle>
-                <CardDescription className="text-xs uppercase tracking-wide text-muted-foreground">
-                  {room?.title ?? "Unknown room"}
-                </CardDescription>
-              </CardHeader>
-              <CardContent className="space-y-3 text-sm">
-                <p className="leading-relaxed text-muted-foreground">{highlight.excerpt}</p>
-                {room && (
-                  <div className="rounded-md border border-dashed border-border px-3 py-2 text-xs text-muted-foreground">
-                    Prompt inspiration: {room.prompts[0]}
-                  </div>
-                )}
-              </CardContent>
-            </Card>
-          );
-        })}
+        {highlights.map((highlight) => (
+          <Card key={highlight.id} className="h-full">
+            <CardHeader>
+              <CardTitle className="flex items-center justify-between text-lg">
+                {highlight.title}
+                <Badge variant="outline">{highlight.roomCode}</Badge>
+              </CardTitle>
+              <CardDescription className="text-xs uppercase tracking-wide text-muted-foreground">
+                {highlight.roomTitle}
+              </CardDescription>
+            </CardHeader>
+            <CardContent className="space-y-3 text-sm">
+              <p className="leading-relaxed text-muted-foreground">{highlight.excerpt}</p>
+            </CardContent>
+          </Card>
+        ))}
       </div>
     </div>
   );

--- a/src/app/page.tsx
+++ b/src/app/page.tsx
@@ -43,6 +43,9 @@ export default function Home() {
               <Link href="/new">Launch a new game</Link>
             </Button>
             <Button asChild size="lg" variant="outline">
+              <Link href="/rooms">Rooms</Link>
+            </Button>
+            <Button asChild size="lg" variant="outline">
               <Link href="/highlights">See community highlights</Link>
             </Button>
           </div>

--- a/src/app/profile/page.tsx
+++ b/src/app/profile/page.tsx
@@ -1,37 +1,70 @@
 import { Metadata } from "next";
+import Link from "next/link";
 
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
 import { Badge } from "@/components/ui/badge";
-import { getRoomSnapshot } from "@/lib/rooms";
-import type { RoomSnapshot } from "@/lib/rooms";
+import { Button } from "@/components/ui/button";
+import { auth } from "@/lib/auth";
+import { listRoomsForUser } from "@/lib/server/rooms";
 
 export const metadata: Metadata = {
   title: "Profile",
   description: "Personal stats, recent turns, and rooms hosted in LingvoJam.",
 };
 
-const VIEWER_ID = "host-1";
+export default async function ProfilePage() {
+  const session = await auth();
 
-export default function ProfilePage() {
-  const rooms = [getRoomSnapshot("improv"), getRoomSnapshot("solo")].filter(
-    Boolean,
-  ) as RoomSnapshot[];
-  const hostedRooms = rooms.filter((room) => room.hostId === VIEWER_ID);
+  if (!session?.user?.id) {
+    return (
+      <div className="space-y-6">
+        <header className="max-w-3xl">
+          <h1 className="text-3xl font-semibold tracking-tight">Your profile</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Sign in to see your rooms, turns, and session stats.
+          </p>
+        </header>
+        <Card>
+          <CardHeader>
+            <CardTitle>Ready to jam?</CardTitle>
+            <CardDescription>
+              Create an account or log in to track your progress across rooms.
+            </CardDescription>
+          </CardHeader>
+          <CardContent>
+            <div className="flex flex-wrap gap-3">
+              <Button asChild>
+                <Link href="/register">Create account</Link>
+              </Button>
+              <Button asChild variant="outline">
+                <Link href="/login">Sign in</Link>
+              </Button>
+            </div>
+          </CardContent>
+        </Card>
+      </div>
+    );
+  }
+
+  const rooms = await listRoomsForUser(session.user.id);
+  const hostedRooms = rooms.filter((room) => room.hostId === session.user?.id);
   const totalTurns = rooms.reduce(
-    (acc, room) => acc + room.turns.filter((turn) => turn.authorId === VIEWER_ID).length,
+    (acc, room) => acc + room.turns.filter((turn) => turn.authorId === session.user?.id).length,
     0,
   );
   const totalScore = rooms.reduce((acc, room) => {
-    const participant = room.participants.find((participant) => participant.id === VIEWER_ID);
+    const participant = room.participants.find((entry) => entry.id === session.user?.id);
     return acc + (participant?.score ?? 0);
   }, 0);
 
   return (
     <div className="space-y-8">
       <header className="max-w-3xl">
-        <h1 className="text-3xl font-semibold tracking-tight">Avery</h1>
+        <h1 className="text-3xl font-semibold tracking-tight">
+          {session.user.name ?? "Lingvo jammer"}
+        </h1>
         <p className="mt-1 text-sm text-muted-foreground">
-          Host, facilitator, and rhyme wrangler. Tracking the latest sessions and victories.
+          Tracking hosted rooms, turn streaks, and community accolades.
         </p>
       </header>
       <div className="grid gap-6 sm:grid-cols-2">
@@ -61,18 +94,26 @@ export default function ProfilePage() {
             <CardDescription>Quick links to keep the story going.</CardDescription>
           </CardHeader>
           <CardContent className="grid gap-3 text-sm">
-            {rooms.map((room) => (
-              <div
-                key={room.id}
-                className="flex items-center justify-between rounded-md border px-3 py-2"
-              >
-                <div>
-                  <p className="font-medium">{room.title}</p>
-                  <p className="text-xs text-muted-foreground">{room.description}</p>
+            {rooms.length === 0 ? (
+              <p className="text-muted-foreground">
+                You haven&apos;t joined any rooms yet. Launch a new one to get started.
+              </p>
+            ) : (
+              rooms.map((room) => (
+                <div
+                  key={room.id}
+                  className="flex items-center justify-between rounded-md border px-3 py-2"
+                >
+                  <div>
+                    <p className="font-medium">{room.title}</p>
+                    {room.description && (
+                      <p className="text-xs text-muted-foreground">{room.description}</p>
+                    )}
+                  </div>
+                  <Badge variant="outline">{room.code}</Badge>
                 </div>
-                <Badge variant="outline">{room.code}</Badge>
-              </div>
-            ))}
+              ))
+            )}
           </CardContent>
         </Card>
       </div>

--- a/src/app/rooms/page.tsx
+++ b/src/app/rooms/page.tsx
@@ -1,0 +1,97 @@
+import { Metadata } from "next";
+import Link from "next/link";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { listRoomSnapshots } from "@/lib/server/rooms";
+
+export const metadata: Metadata = {
+  title: "Rooms",
+  description: "Browse active LingvoJam sessions and jump into the story.",
+};
+
+function formatDistanceToNow(timestamp: string): string {
+  const value = new Date(timestamp).getTime();
+  const diffMs = Date.now() - value;
+  const seconds = Math.max(0, Math.floor(diffMs / 1000));
+  if (seconds < 60) {
+    return `${seconds}s ago`;
+  }
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) {
+    return `${minutes}m ago`;
+  }
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) {
+    return `${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days}d ago`;
+}
+
+export default async function RoomsPage() {
+  const rooms = await listRoomSnapshots();
+
+  return (
+    <div className="space-y-8">
+      <header className="flex flex-col gap-3 sm:flex-row sm:items-end sm:justify-between">
+        <div>
+          <h1 className="text-3xl font-semibold tracking-tight">Active rooms</h1>
+          <p className="mt-1 text-sm text-muted-foreground">
+            Browse current jams, peek at the rules, and join the vibe that suits your crew.
+          </p>
+        </div>
+        <Button asChild>
+          <Link href="/new">Launch a new game</Link>
+        </Button>
+      </header>
+      <div className="grid gap-6 lg:grid-cols-2">
+        {rooms.map((room) => {
+          const host = room.participants.find((participant) => participant.id === room.hostId);
+          return (
+            <Card key={room.id} className="flex h-full flex-col justify-between">
+              <CardHeader>
+                <div className="flex items-center justify-between gap-3">
+                  <div>
+                    <CardTitle className="text-xl">{room.title}</CardTitle>
+                    <CardDescription className="text-xs uppercase tracking-wide text-muted-foreground">
+                      Hosted by {host?.name ?? "Unknown"}
+                    </CardDescription>
+                  </div>
+                  <Badge variant="outline">{room.code}</Badge>
+                </div>
+              </CardHeader>
+              <CardContent className="space-y-4 text-sm">
+                {room.description && <p className="text-muted-foreground">{room.description}</p>}
+                <div className="flex flex-wrap items-center gap-3 text-xs text-muted-foreground">
+                  <span>{room.participants.length} players</span>
+                  <span>·</span>
+                  <span>{room.turns.length} turns</span>
+                  <span>·</span>
+                  <span>Updated {formatDistanceToNow(room.createdAt)}</span>
+                </div>
+                <div className="flex flex-wrap gap-2 text-xs text-muted-foreground">
+                  {room.rules.map((rule) => (
+                    <Badge key={JSON.stringify(rule)} variant="secondary">
+                      {rule.type === "maxWords"
+                        ? `${rule.value} words`
+                        : rule.type === "maxSentences"
+                          ? `${rule.value} sentences`
+                          : rule.type === "forbidden"
+                            ? `Avoid: ${rule.value.join(", ")}`
+                            : `Rhyme with "${rule.value}"`}
+                    </Badge>
+                  ))}
+                </div>
+                <Button asChild variant="outline" size="sm">
+                  <Link href={`/r/${room.id}`}>View room</Link>
+                </Button>
+              </CardContent>
+            </Card>
+          );
+        })}
+      </div>
+    </div>
+  );
+}

--- a/src/components/room/turn-composer.tsx
+++ b/src/components/room/turn-composer.tsx
@@ -75,13 +75,21 @@ export function TurnComposer() {
 
     try {
       setIsSubmitting(true);
-      submitTurn({ content: result.sanitized, authorId: currentPlayer.id });
-      toast({
-        title: "Turn submitted",
-        description: "Your riff is live in the feed.",
-      });
-      setDraft("");
-      dismissSuggestion();
+      const turn = await submitTurn({ content: result.sanitized, authorId: currentPlayer.id });
+      if (turn) {
+        toast({
+          title: "Turn submitted",
+          description: "Your riff is live in the feed.",
+        });
+        setDraft("");
+        dismissSuggestion();
+      } else {
+        toast({
+          title: "Unable to submit turn",
+          description: "Please try again in a moment.",
+          variant: "destructive",
+        });
+      }
     } finally {
       setIsSubmitting(false);
     }

--- a/src/components/room/vote-bar.tsx
+++ b/src/components/room/vote-bar.tsx
@@ -1,5 +1,6 @@
 "use client";
 
+import * as React from "react";
 import { ArrowBigDown, ArrowBigUp } from "lucide-react";
 
 import { Button } from "@/components/ui/button";
@@ -14,10 +15,23 @@ interface VoteBarProps {
 
 export function VoteBar({ turn, viewerId }: VoteBarProps) {
   const { castVote } = useRoom();
+  const [isSubmitting, setIsSubmitting] = React.useState(false);
   const positiveVotes = turn.votes.filter((vote) => vote.value > 0).length;
   const totalVotes = turn.votes.length;
   const percentage = totalVotes > 0 ? Math.round((positiveVotes / totalVotes) * 100) : 0;
   const viewerVote = turn.votes.find((vote) => vote.voterId === viewerId)?.value ?? 0;
+
+  const handleVote = async (value: number) => {
+    if (isSubmitting) {
+      return;
+    }
+    setIsSubmitting(true);
+    try {
+      await castVote(turn.id, viewerId, value);
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
 
   return (
     <div className="space-y-2">
@@ -37,7 +51,8 @@ export function VoteBar({ turn, viewerId }: VoteBarProps) {
           type="button"
           variant={viewerVote > 0 ? "secondary" : "outline"}
           size="sm"
-          onClick={() => castVote(turn.id, viewerId, viewerVote > 0 ? 0 : 1)}
+          disabled={isSubmitting}
+          onClick={() => handleVote(viewerVote > 0 ? 0 : 1)}
         >
           <ArrowBigUp className="mr-2 h-4 w-4" /> Cheer
         </Button>
@@ -45,7 +60,8 @@ export function VoteBar({ turn, viewerId }: VoteBarProps) {
           type="button"
           variant={viewerVote < 0 ? "destructive" : "outline"}
           size="sm"
-          onClick={() => castVote(turn.id, viewerId, viewerVote < 0 ? 0 : -1)}
+          disabled={isSubmitting}
+          onClick={() => handleVote(viewerVote < 0 ? 0 : -1)}
         >
           <ArrowBigDown className="mr-2 h-4 w-4" /> Skip
         </Button>

--- a/src/lib/rooms.ts
+++ b/src/lib/rooms.ts
@@ -1,5 +1,3 @@
-import { nanoid } from "nanoid";
-
 export type RoomRule =
   | { type: "maxWords"; value: number }
   | { type: "maxSentences"; value: number }
@@ -33,7 +31,9 @@ export interface RoomHighlight {
   title: string;
   excerpt: string;
   roomId: string;
-  turnId: string;
+  roomTitle: string;
+  roomCode: string;
+  turnId?: string;
   createdAt: string;
 }
 
@@ -43,7 +43,7 @@ export interface RoomSnapshot {
   title: string;
   description?: string;
   createdAt: string;
-  hostId: string;
+  hostId?: string;
   participants: RoomParticipant[];
   turns: RoomTurn[];
   rules: RoomRule[];
@@ -51,169 +51,61 @@ export interface RoomSnapshot {
   highlights: RoomHighlight[];
 }
 
-const demoRooms: Record<string, RoomSnapshot> = {
-  improv: {
-    id: "improv",
-    code: "IMPROV",
-    title: "LingvoJam Friday Night",
-    description: "Fast-paced rhyme-and-response round robin.",
-    createdAt: new Date(Date.now() - 1000 * 60 * 60 * 4).toISOString(),
-    hostId: "host-1",
-    participants: [
-      { id: "host-1", name: "Avery", avatar: "A", score: 42, isHost: true },
-      { id: "guest-1", name: "Blake", avatar: "B", score: 36 },
-      { id: "guest-2", name: "Charlie", avatar: "C", score: 28 },
-    ],
-    prompts: [
-      'Wordplay warmup: riff on "midnight sparks"',
-      'Respond with a line that rhymes with "velvet"',
-      "Invent a rule for round three",
-    ],
-    rules: [
-      { type: "maxWords", value: 40 },
-      { type: "maxSentences", value: 2 },
-      { type: "forbidden", value: ["boring", "skip"] },
-      { type: "rhyme", value: "velvet" },
-    ],
-    turns: [
-      {
-        id: "turn-1",
-        round: 1,
-        prompt: 'Wordplay warmup: riff on "midnight sparks"',
-        content: "Midnight sparks sketch stories in the smog",
-        authorId: "host-1",
-        status: "published",
-        createdAt: new Date(Date.now() - 1000 * 60 * 55).toISOString(),
-        publishedAt: new Date(Date.now() - 1000 * 60 * 54).toISOString(),
-        votes: [
-          { voterId: "guest-1", value: 1 },
-          { voterId: "guest-2", value: 1 },
-        ],
-      },
-      {
-        id: "turn-2",
-        round: 1,
-        prompt: 'Wordplay warmup: riff on "midnight sparks"',
-        content: "Thunderclap cadences chasing down the fog",
-        authorId: "guest-1",
-        status: "published",
-        createdAt: new Date(Date.now() - 1000 * 60 * 50).toISOString(),
-        publishedAt: new Date(Date.now() - 1000 * 60 * 49).toISOString(),
-        votes: [
-          { voterId: "host-1", value: 1 },
-          { voterId: "guest-2", value: 1 },
-        ],
-      },
-      {
-        id: "turn-3",
-        round: 2,
-        prompt: 'Respond with a line that rhymes with "velvet"',
-        content: "Silver-threaded syllables melt velvet",
-        authorId: "guest-2",
-        status: "published",
-        createdAt: new Date(Date.now() - 1000 * 60 * 25).toISOString(),
-        publishedAt: new Date(Date.now() - 1000 * 60 * 24).toISOString(),
-        votes: [
-          { voterId: "host-1", value: 1 },
-          { voterId: "guest-1", value: 1 },
-        ],
-      },
-      {
-        id: "turn-4",
-        round: 3,
-        prompt: "Invent a rule for round three",
-        content: "New decree: verbs must pirouette in present tense",
-        authorId: "host-1",
-        status: "validated",
-        createdAt: new Date(Date.now() - 1000 * 60 * 5).toISOString(),
-        votes: [],
-      },
-    ],
-    highlights: [
-      {
-        id: "highlight-1",
-        roomId: "improv",
-        turnId: "turn-2",
-        title: "Thunderclap Cadence",
-        excerpt: "Thunderclap cadences chasing down the fog",
-        createdAt: new Date(Date.now() - 1000 * 60 * 45).toISOString(),
-      },
-    ],
-  },
-  solo: {
-    id: "solo",
-    code: "SOLO01",
-    title: "Solo Flow Studio",
-    description: "Practice pad for single-player experimentation.",
-    createdAt: new Date(Date.now() - 1000 * 60 * 30).toISOString(),
-    hostId: "solo-1",
-    participants: [{ id: "solo-1", name: "River", avatar: "R", score: 18, isHost: true }],
-    prompts: [
-      "Write a metaphor about sunrise",
-      "Flip it into a question",
-      "Answer using only two sentences",
-    ],
-    rules: [
-      { type: "maxWords", value: 60 },
-      { type: "maxSentences", value: 2 },
-    ],
-    turns: [
-      {
-        id: "solo-turn-1",
-        round: 1,
-        prompt: "Write a metaphor about sunrise",
-        content: "Sunrise is a vinyl record restarting a worn chorus",
-        authorId: "solo-1",
-        status: "published",
-        createdAt: new Date(Date.now() - 1000 * 60 * 20).toISOString(),
-        publishedAt: new Date(Date.now() - 1000 * 60 * 19).toISOString(),
-        votes: [],
-      },
-    ],
-    highlights: [
-      {
-        id: "highlight-2",
-        roomId: "solo",
-        turnId: "solo-turn-1",
-        title: "Sunrise Spinning",
-        excerpt: "Sunrise is a vinyl record restarting a worn chorus",
-        createdAt: new Date(Date.now() - 1000 * 60 * 18).toISOString(),
-      },
-    ],
-  },
+export type RoomRecap = {
+  room: RoomSnapshot;
+  totalVotes: number;
+  winningTurn?: RoomTurn;
+  scoreByParticipant: Array<{ participant: RoomParticipant; score: number }>;
 };
 
-export function getRoomSnapshot(roomId: string): RoomSnapshot | null {
-  return demoRooms[roomId] ?? null;
+export function calculateParticipantScores(
+  participants: RoomParticipant[],
+  turns: RoomTurn[],
+): RoomParticipant[] {
+  const scoreMap = new Map<string, number>();
+  participants.forEach((participant) => {
+    scoreMap.set(participant.id, 0);
+  });
+
+  turns.forEach((turn) => {
+    if (!turn.authorId) {
+      return;
+    }
+
+    const existing = scoreMap.get(turn.authorId) ?? 0;
+    const voteScore = turn.votes.reduce((acc, vote) => acc + vote.value, 0);
+    scoreMap.set(turn.authorId, existing + 2 + voteScore);
+  });
+
+  return participants.map((participant) => ({
+    ...participant,
+    score: Math.max(0, scoreMap.get(participant.id) ?? participant.score ?? 0),
+  }));
 }
 
-export function listHighlights(): RoomHighlight[] {
-  return Object.values(demoRooms).flatMap((room) => room.highlights);
-}
+export function buildRecapFromSnapshot(snapshot: RoomSnapshot): RoomRecap {
+  let winningTurn: RoomTurn | undefined;
+  let winningScore = -Infinity;
+  let totalVotes = 0;
 
-export function upsertDemoTurn(
-  roomId: string,
-  turn: Partial<RoomTurn> & { authorId: string; prompt: string },
-): RoomTurn {
-  const room = demoRooms[roomId];
-  if (!room) {
-    throw new Error(`Unknown room ${roomId}`);
-  }
+  snapshot.turns.forEach((turn) => {
+    const turnScore = turn.votes.reduce((acc, vote) => acc + vote.value, 0);
+    totalVotes += turn.votes.length;
+    if (turnScore > winningScore) {
+      winningScore = turnScore;
+      winningTurn = turn;
+    }
+  });
 
-  const newTurn: RoomTurn = {
-    id: turn.id ?? nanoid(),
-    round: turn.round ?? room.turns.length + 1,
-    content: turn.content ?? "",
-    status: turn.status ?? "proposed",
-    createdAt: new Date().toISOString(),
-    votes: turn.votes ?? [],
-    publishedAt: turn.publishedAt,
-    prompt: turn.prompt,
-    authorId: turn.authorId,
+  return {
+    room: snapshot,
+    totalVotes,
+    winningTurn,
+    scoreByParticipant: snapshot.participants.map((participant) => ({
+      participant,
+      score: participant.score,
+    })),
   };
-
-  room.turns = [...room.turns.filter((existing) => existing.id !== newTurn.id), newTurn];
-  return newTurn;
 }
 
 const soloSuggestionPhrases = [
@@ -242,49 +134,4 @@ export function roomRuleLabel(rule: RoomRule): string {
     default:
       return "Special rule";
   }
-}
-
-export type RoomRecap = {
-  room: RoomSnapshot;
-  totalVotes: number;
-  winningTurn?: RoomTurn;
-  scoreByParticipant: Array<{ participant: RoomParticipant; score: number }>;
-};
-
-export function buildRoomRecap(roomId: string): RoomRecap | null {
-  const room = getRoomSnapshot(roomId);
-  if (!room) {
-    return null;
-  }
-
-  const scoreMap = new Map<string, number>();
-  room.participants.forEach((participant) => {
-    scoreMap.set(participant.id, participant.score);
-  });
-
-  let winningTurn: RoomTurn | undefined;
-  let winningScore = -Infinity;
-  let totalVotes = 0;
-
-  room.turns.forEach((turn) => {
-    const turnScore = turn.votes.reduce((acc, vote) => acc + vote.value, 0);
-    totalVotes += turn.votes.length;
-
-    if (turnScore > winningScore) {
-      winningScore = turnScore;
-      winningTurn = turn;
-    }
-  });
-
-  const scoreByParticipant = room.participants.map((participant) => ({
-    participant,
-    score: scoreMap.get(participant.id) ?? 0,
-  }));
-
-  return {
-    room,
-    totalVotes,
-    winningTurn,
-    scoreByParticipant,
-  };
 }

--- a/src/lib/server/rooms.ts
+++ b/src/lib/server/rooms.ts
@@ -1,0 +1,302 @@
+import "server-only";
+
+import type { Prisma } from "@prisma/client";
+import { RoomRole } from "@prisma/client";
+
+import {
+  buildRecapFromSnapshot,
+  calculateParticipantScores,
+  type RoomHighlight,
+  type RoomParticipant,
+  type RoomRecap,
+  type RoomRule,
+  type RoomSnapshot,
+  type RoomTurn,
+  type TurnStatus,
+} from "@/lib/rooms";
+import { prisma } from "@/lib/prisma";
+
+type RoomWithRelations = Prisma.RoomGetPayload<{
+  include: {
+    memberships: {
+      include: {
+        user: {
+          select: {
+            id: true;
+            name: true;
+            image: true;
+          };
+        };
+      };
+    };
+    turns: {
+      orderBy: { createdAt: "asc" };
+      include: {
+        votes: true;
+      };
+    };
+    summaries: {
+      orderBy: { createdAt: "desc" };
+      include: {
+        turn: {
+          select: {
+            id: true;
+            prompt: true;
+            content: true;
+          };
+        };
+      };
+    };
+  };
+}>;
+
+export type TurnWithVotes = Prisma.TurnGetPayload<{
+  include: {
+    votes: true;
+  };
+}>;
+
+type SummaryWithTurn = Prisma.SummaryGetPayload<{
+  include: {
+    turn: {
+      select: {
+        id: true;
+        prompt: true;
+        content: true;
+      };
+    };
+    room: {
+      select: {
+        id: true;
+        title: true;
+        code: true;
+      };
+    };
+  };
+}>;
+
+export function toRoomTurn(turn: TurnWithVotes): RoomTurn {
+  const status: TurnStatus = turn.content ? "published" : turn.endedAt ? "validated" : "proposed";
+
+  return {
+    id: turn.id,
+    round: turn.round,
+    prompt: turn.prompt,
+    content: turn.content ?? "",
+    authorId: turn.authorId ?? "",
+    status,
+    createdAt: turn.startedAt.toISOString(),
+    publishedAt: turn.endedAt?.toISOString(),
+    votes: turn.votes.map((vote) => ({
+      voterId: vote.voterId,
+      value: vote.value,
+    })),
+  };
+}
+
+function deriveRules(room: RoomWithRelations): RoomRule[] {
+  const rules: RoomRule[] = [
+    { type: "maxWords", value: room.maxWords },
+    { type: "maxSentences", value: room.maxSentences },
+  ];
+
+  if (room.forbiddenWords.length > 0) {
+    rules.push({ type: "forbidden", value: room.forbiddenWords });
+  }
+
+  if (room.rhymeTarget) {
+    rules.push({ type: "rhyme", value: room.rhymeTarget });
+  }
+
+  return rules;
+}
+
+function mapParticipants(room: RoomWithRelations): RoomParticipant[] {
+  return room.memberships.map((membership) => {
+    const name = membership.user?.name ?? "Anonymous";
+    const avatar = membership.user?.image ?? name.charAt(0) ?? undefined;
+    return {
+      id: membership.userId,
+      name,
+      avatar,
+      score: 0,
+      isHost: membership.role === RoomRole.HOST,
+    } satisfies RoomParticipant;
+  });
+}
+
+function mapSummaryToHighlight(summary: SummaryWithTurn): RoomHighlight {
+  const excerpt = summary.turn?.content ?? summary.content;
+  const title = summary.turn?.prompt ?? `${summary.room.title} recap`;
+
+  return {
+    id: summary.id,
+    roomId: summary.roomId,
+    roomTitle: summary.room.title,
+    roomCode: summary.room.code,
+    turnId: summary.turn?.id ?? undefined,
+    title,
+    excerpt,
+    createdAt: summary.createdAt.toISOString(),
+  };
+}
+
+function derivePrompts(room: RoomWithRelations, turns: RoomTurn[]): string[] {
+  if (room.prompts.length > 0) {
+    return [...room.prompts];
+  }
+
+  const prompts = Array.from(new Set(turns.map((turn) => turn.prompt).filter(Boolean)));
+  if (prompts.length === 0) {
+    prompts.push("Start the story with your first prompt.");
+  }
+  return prompts;
+}
+
+function mapRoom(room: RoomWithRelations): RoomSnapshot {
+  const participants = mapParticipants(room);
+  const turns = room.turns.map(toRoomTurn);
+  const participantsWithScores = calculateParticipantScores(participants, turns);
+  const highlights = room.summaries.map((summary) =>
+    mapSummaryToHighlight({
+      ...summary,
+      room: { id: room.id, title: room.title, code: room.code },
+    } as SummaryWithTurn),
+  );
+
+  return {
+    id: room.id,
+    code: room.code,
+    title: room.title,
+    description: room.description ?? undefined,
+    createdAt: room.createdAt.toISOString(),
+    hostId: room.hostId ?? undefined,
+    participants: participantsWithScores,
+    turns,
+    rules: deriveRules(room),
+    prompts: derivePrompts(room, turns),
+    highlights,
+  };
+}
+
+export async function getRoomSnapshot(roomId: string): Promise<RoomSnapshot | null> {
+  const room = await prisma.room.findUnique({
+    where: { id: roomId },
+    include: {
+      memberships: {
+        include: {
+          user: {
+            select: { id: true, name: true, image: true },
+          },
+        },
+      },
+      turns: {
+        orderBy: { createdAt: "asc" },
+        include: { votes: true },
+      },
+      summaries: {
+        orderBy: { createdAt: "desc" },
+        include: {
+          turn: { select: { id: true, prompt: true, content: true } },
+        },
+      },
+    },
+  });
+
+  if (!room) {
+    return null;
+  }
+
+  return mapRoom(room);
+}
+
+export async function listRoomSnapshots(): Promise<RoomSnapshot[]> {
+  const rooms = await prisma.room.findMany({
+    orderBy: { createdAt: "desc" },
+    include: {
+      memberships: {
+        include: {
+          user: {
+            select: { id: true, name: true, image: true },
+          },
+        },
+      },
+      turns: {
+        orderBy: { createdAt: "asc" },
+        include: { votes: true },
+      },
+      summaries: {
+        orderBy: { createdAt: "desc" },
+        include: {
+          turn: { select: { id: true, prompt: true, content: true } },
+        },
+      },
+    },
+  });
+
+  return rooms.map(mapRoom);
+}
+
+export async function listHighlights(limit = 12): Promise<RoomHighlight[]> {
+  const summaries = await prisma.summary.findMany({
+    orderBy: { createdAt: "desc" },
+    take: limit,
+    include: {
+      turn: { select: { id: true, prompt: true, content: true } },
+      room: { select: { id: true, title: true, code: true } },
+    },
+  });
+
+  return summaries.map((summary) => mapSummaryToHighlight(summary as SummaryWithTurn));
+}
+
+export async function listRoomsForUser(userId: string): Promise<RoomSnapshot[]> {
+  const rooms = await prisma.room.findMany({
+    where: {
+      memberships: {
+        some: { userId },
+      },
+    },
+    orderBy: { createdAt: "desc" },
+    include: {
+      memberships: {
+        include: {
+          user: {
+            select: { id: true, name: true, image: true },
+          },
+        },
+      },
+      turns: {
+        orderBy: { createdAt: "asc" },
+        include: { votes: true },
+      },
+      summaries: {
+        orderBy: { createdAt: "desc" },
+        include: {
+          turn: { select: { id: true, prompt: true, content: true } },
+        },
+      },
+    },
+  });
+
+  return rooms.map(mapRoom);
+}
+
+export async function buildRoomRecap(roomId: string): Promise<RoomRecap | null> {
+  const snapshot = await getRoomSnapshot(roomId);
+  if (!snapshot) {
+    return null;
+  }
+
+  return buildRecapFromSnapshot(snapshot);
+}
+
+export async function ensureMembership(roomId: string, userId: string) {
+  const existing = await prisma.membership.findFirst({
+    where: { roomId, userId },
+  });
+
+  if (!existing) {
+    throw new Error("User is not a member of this room");
+  }
+}


### PR DESCRIPTION
## Summary
- add persisted room configuration columns and migration for prompts and rules
- expose server-side room snapshot helpers with new API endpoints for room creation, turns, and votes
- refactor client experience to use live Prisma data, add Rooms index, and update profile/highlights views

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3dbe417a08333a3c3b46132734ba0