### PR TITLE
Add story summary view and preserve turn line breaks

### DIFF
--- a/src/components/room/room-experience.tsx
+++ b/src/components/room/room-experience.tsx
@@ -9,6 +9,7 @@ import { TurnFeed } from "@/components/room/turn-feed";
 import { ScorePills } from "@/components/room/score-pills";
 import { RecapView } from "@/components/room/recap-view";
 import { useRoom } from "@/components/room/room-provider";
+import { TurnStory } from "@/components/room/turn-story";
 
 interface RoomExperienceProps {
   viewerId?: string;
@@ -41,11 +42,12 @@ export function RoomExperience({ viewerId }: RoomExperienceProps) {
       <RoomTimer />
       <div className="grid gap-6 lg:grid-cols-[2fr,1fr]">
         <div className="space-y-6">
+          <TurnStory />
           <TurnComposer />
-          <TurnFeed viewerId={resolvedViewerId} />
         </div>
         <div className="space-y-6">
           <ScorePills />
+          <TurnFeed viewerId={resolvedViewerId} />
           <RecapView />
         </div>
       </div>

--- a/src/components/room/turn-feed.tsx
+++ b/src/components/room/turn-feed.tsx
@@ -77,7 +77,9 @@ function TurnCard({ turn, viewerId, authorName }: TurnCardProps) {
         </div>
       </CardHeader>
       <CardContent className="space-y-4">
-        <p className="text-sm leading-relaxed text-muted-foreground">{turn.content}</p>
+        <p className="whitespace-pre-wrap text-sm leading-relaxed text-muted-foreground">
+          {turn.content}
+        </p>
         <div className="flex flex-wrap items-center justify-between gap-3 text-xs">
           <span className="font-medium text-foreground">By {authorName}</span>
           <VoteBar turn={turn} viewerId={viewerId} />

--- a/src/components/room/turn-story.tsx
+++ b/src/components/room/turn-story.tsx
@@ -1,0 +1,57 @@
+"use client";
+
+import * as React from "react";
+
+import { Card, CardContent, CardDescription, CardHeader, CardTitle } from "@/components/ui/card";
+import { useRoom } from "@/components/room/room-provider";
+
+export function TurnStory() {
+  const { turns, participants } = useRoom();
+
+  const orderedTurns = React.useMemo(
+    () =>
+      [...turns]
+        .sort((a, b) => new Date(a.createdAt).getTime() - new Date(b.createdAt).getTime())
+        .filter((turn) => turn.content.trim().length > 0),
+    [turns],
+  );
+
+  const authorLookup = React.useMemo(() => {
+    return new Map(participants.map((participant) => [participant.id, participant.name]));
+  }, [participants]);
+
+  if (orderedTurns.length === 0) {
+    return (
+      <Card>
+        <CardHeader>
+          <CardTitle>Story so far</CardTitle>
+          <CardDescription>The room hasn&apos;t collected any lines yet.</CardDescription>
+        </CardHeader>
+      </Card>
+    );
+  }
+
+  return (
+    <Card>
+      <CardHeader>
+        <CardTitle>Story so far</CardTitle>
+        <CardDescription>
+          {orderedTurns.length} {orderedTurns.length === 1 ? "contribution" : "contributions"}{" "}
+          building the narrative
+        </CardDescription>
+      </CardHeader>
+      <CardContent className="space-y-6">
+        {orderedTurns.map((turn) => (
+          <article key={turn.id} className="space-y-2">
+            <div className="text-xs font-medium uppercase tracking-wide text-muted-foreground">
+              Round {turn.round} · {authorLookup.get(turn.authorId) ?? "Unknown"}
+            </div>
+            <p className="whitespace-pre-wrap text-sm leading-relaxed text-foreground">
+              {turn.content}
+            </p>
+          </article>
+        ))}
+      </CardContent>
+    </Card>
+  );
+}

--- a/src/lib/text.ts
+++ b/src/lib/text.ts
@@ -9,15 +9,23 @@ export interface RhymeDetails {
   fragment: string | null;
 }
 
-const CONTROL_CHARS = /[\u0000-\u001F\u007F]/g;
-const MULTIPLE_SPACES = /\s+/g;
+const CONTROL_CHARS_EXCEPT_LINE_FEED = /[\u0000-\u0009\u000B-\u001F\u007F]/g;
+const WHITESPACE_EXCEPT_LINE_FEED = /[^\S\n]+/g;
 const RHYME_WORD_REGEX = /[a-zA-Z']+/g;
 
 /**
  * Normalizes arbitrary user input so it can be shared safely between the client and server.
  */
 export function sanitize(input: string): string {
-  return input.normalize("NFKC").replace(CONTROL_CHARS, " ").replace(MULTIPLE_SPACES, " ").trim();
+  return input
+    .normalize("NFKC")
+    .replace(/\r\n?/g, "\n")
+    .replace(CONTROL_CHARS_EXCEPT_LINE_FEED, " ")
+    .replace(WHITESPACE_EXCEPT_LINE_FEED, " ")
+    .split("\n")
+    .map((line) => line.trim())
+    .join("\n")
+    .trim();
 }
 
 /**
@@ -29,7 +37,7 @@ export function wordCount(input: string): number {
     return 0;
   }
 
-  return normalized.split(" ").length;
+  return normalized.split(/\s+/).filter(Boolean).length;
 }
 
 function extractLastWord(input: string): string | null {

--- a/src/lib/turn-validation.test.ts
+++ b/src/lib/turn-validation.test.ts
@@ -12,6 +12,15 @@ describe("validateTurn", () => {
     expect(result.errors).toEqual([]);
   });
 
+  it("preserves line breaks while sanitizing", () => {
+    const result = validateTurn(" First line\nSecond   line \n ");
+
+    expect(result.isValid).toBe(true);
+    expect(result.sanitized).toBe("First line\nSecond line");
+    expect(result.wordTotal).toBe(4);
+    expect(result.sentenceTotal).toBe(1);
+  });
+
   it("flags turns exceeding the maximum word count", () => {
     const result = validateTurn("one two three four", { maxWords: 3, maxSentences: 5 });
 


### PR DESCRIPTION
## Summary
- add a "Story so far" panel in the room experience that lists each turn in order
- ensure turn content keeps line breaks in both the feed and validation pipeline
- cover the new sanitization behaviour with automated tests

## Testing
- npm test

------
https://chatgpt.com/codex/tasks/task_e_68e3f396a5088333bb76db4966bd2c91