### PR TITLE
Fix room API handlers to await dynamic params

### DIFF
--- a/src/app/api/rooms/[id]/join/route.ts
+++ b/src/app/api/rooms/[id]/join/route.ts
@@ -4,10 +4,11 @@ import { prisma } from "@/lib/prisma";
 import { emitToRoom } from "@/lib/realtime/server";
 
 interface RouteParams {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
-export async function POST(request: Request, { params }: RouteParams) {
+export async function POST(request: Request, context: RouteParams) {
+  const params = await context.params;
   try {
     const body = await request.json();
     const { userId, role } = body ?? {};

--- a/src/app/api/rooms/[id]/recap/route.ts
+++ b/src/app/api/rooms/[id]/recap/route.ts
@@ -5,7 +5,7 @@ import { roomRuleLabel } from "@/lib/rooms";
 import { buildRoomRecap } from "@/lib/server/rooms";
 
 interface RouteParams {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
 async function buildTextRecap(id: string) {
@@ -78,7 +78,8 @@ async function buildHtmlRecap(id: string) {
     </html>`;
 }
 
-export async function GET(request: NextRequest, { params }: RouteParams) {
+export async function GET(request: NextRequest, context: RouteParams) {
+  const params = await context.params;
   const format = request.nextUrl.searchParams.get("format") ?? "pdf";
   const textRecap = await buildTextRecap(params.id);
 

--- a/src/app/api/rooms/[id]/route.ts
+++ b/src/app/api/rooms/[id]/route.ts
@@ -3,10 +3,11 @@ import { NextResponse } from "next/server";
 import { prisma } from "@/lib/prisma";
 
 interface RouteParams {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
-export async function GET(_request: Request, { params }: RouteParams) {
+export async function GET(_request: Request, context: RouteParams) {
+  const params = await context.params;
   try {
     const room = await prisma.room.findUnique({
       where: { id: params.id },

--- a/src/app/api/rooms/[id]/start/route.ts
+++ b/src/app/api/rooms/[id]/start/route.ts
@@ -4,10 +4,11 @@ import { prisma } from "@/lib/prisma";
 import { emitToRoom, startRoomTimer } from "@/lib/realtime/server";
 
 interface RouteParams {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
-export async function POST(request: Request, { params }: RouteParams) {
+export async function POST(request: Request, context: RouteParams) {
+  const params = await context.params;
   try {
     const body = await request.json();
     const { hostId, duration } = body ?? {};

--- a/src/app/api/rooms/[id]/turn/route.ts
+++ b/src/app/api/rooms/[id]/turn/route.ts
@@ -5,10 +5,11 @@ import { emitToRoom } from "@/lib/realtime/server";
 import { DEFAULT_TURN_VALIDATION, validateTurn } from "@/lib/turn-validation";
 
 interface RouteParams {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
-export async function POST(request: Request, { params }: RouteParams) {
+export async function POST(request: Request, context: RouteParams) {
+  const params = await context.params;
   try {
     const body = await request.json();
     const { action, round, prompt, content, authorId, turnId, validationOptions } = body ?? {};

--- a/src/app/api/rooms/[id]/turns/[turnId]/vote/route.ts
+++ b/src/app/api/rooms/[id]/turns/[turnId]/vote/route.ts
@@ -5,10 +5,11 @@ import { prisma } from "@/lib/prisma";
 import { toRoomTurn } from "@/lib/server/rooms";
 
 interface RouteParams {
-  params: { id: string; turnId: string };
+  params: Promise<{ id: string; turnId: string }>;
 }
 
-export async function PATCH(request: Request, { params }: RouteParams) {
+export async function PATCH(request: Request, context: RouteParams) {
+  const params = await context.params;
   try {
     const session = await auth();
     if (!session?.user?.id) {

--- a/src/app/api/rooms/[id]/turns/route.ts
+++ b/src/app/api/rooms/[id]/turns/route.ts
@@ -5,10 +5,11 @@ import { prisma } from "@/lib/prisma";
 import { toRoomTurn } from "@/lib/server/rooms";
 
 interface RouteParams {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
-export async function POST(request: Request, { params }: RouteParams) {
+export async function POST(request: Request, context: RouteParams) {
+  const params = await context.params;
   try {
     const session = await auth();
     if (!session?.user?.id) {

--- a/src/app/api/rooms/[id]/vote/route.ts
+++ b/src/app/api/rooms/[id]/vote/route.ts
@@ -4,10 +4,11 @@ import { prisma } from "@/lib/prisma";
 import { emitToRoom } from "@/lib/realtime/server";
 
 interface RouteParams {
-  params: { id: string };
+  params: Promise<{ id: string }>;
 }
 
-export async function POST(request: Request, { params }: RouteParams) {
+export async function POST(request: Request, context: RouteParams) {
+  const params = await context.params;
   try {
     const body = await request.json();
     const { turnId, voterId, value } = body ?? {};


### PR DESCRIPTION
## Summary
- await the promise-based params object in every room API handler so dynamic routes comply with Next.js expectations and no longer throw at runtime

## Testing
- npm run lint

------
https://chatgpt.com/codex/tasks/task_e_68e3f5bc29688333aa34e00e9e20f65e